### PR TITLE
Add a warnNA argument to stop annoying messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/journey.R
+++ b/R/journey.R
@@ -129,7 +129,7 @@ journey <- function(from,
                     distance_cutoff = 50,
                     gradient_cutoff = 0.1,
                     n = 3,
-                    warnNA = TRUE) {
+                    warnNA = FALSE) {
   if (is.null(pat))
     pat = Sys.getenv("CYCLESTREETS")
   orig <- paste0(from, collapse = ",")

--- a/R/journey.R
+++ b/R/journey.R
@@ -128,7 +128,8 @@ journey <- function(from,
                     smooth_gradient = TRUE,
                     distance_cutoff = 50,
                     gradient_cutoff = 0.1,
-                    n = 3) {
+                    n = 3,
+                    warnNA = TRUE) {
   if (is.null(pat))
     pat = Sys.getenv("CYCLESTREETS")
   orig <- paste0(from, collapse = ",")
@@ -177,7 +178,8 @@ journey <- function(from,
       smooth_gradient,
       distance_cutoff,
       gradient_cutoff,
-      n
+      n,
+      warnNA = warnNA
     )
   }
   r
@@ -250,7 +252,8 @@ json2sf_cs <- function(obj,
                        smooth_gradient = FALSE,
                        distance_cutoff = 50,
                        gradient_cutoff = 0.1,
-                       n = 3) {
+                       n = 3,
+                       warnNA = TRUE) {
 
   coord_list = lapply(obj$marker$`@attributes`$points[-1], txt2coords)
   elev_list = lapply(obj$marker$`@attributes`$elevations[-1], txt2elevations)
@@ -388,7 +391,8 @@ json2sf_cs <- function(obj,
         r$distances,
         distance_cutoff,
         gradient_cutoff,
-        n
+        n,
+        warnNA = warnNA
       )
     } else {
       r$gradient_smooth = r$gradient_segment
@@ -412,6 +416,7 @@ json2sf_cs <- function(obj,
 #' @param distance_cutoff Distance (m) used to identify anomalous gradients
 #' @param gradient_cutoff Gradient (%, e.g. 0.1 being 10%) used to identify anomalous gradients
 #' @param n The number of segments to use to smooth anomalous gradents.
+#' @param warnNA Logical should NA warning be given?
 #' The default is 3, meaning segments directly before, after and including the offending segment.
 #' @export
 #' @examples
@@ -430,7 +435,8 @@ smooth_with_cutoffs = function(gradient_segment,
                                distances,
                                distance_cutoff = 50,
                                gradient_cutoff = 0.1,
-                               n = 3) {
+                               n = 3,
+                               warnNA = TRUE) {
   sel = gradient_segment > gradient_cutoff &
     distances <= distance_cutoff
   gradient_segment_smooth =
@@ -440,7 +446,9 @@ smooth_with_cutoffs = function(gradient_segment,
   gradient_segment[sel] = gradient_segment_smooth[sel]
 
   if (any(is.na(gradient_segment))) {
-    message("NA values detected")
+    if(warnNA){
+      message("NA values detected")
+    }
     gradient_segment[is.na(gradient_segment)] =
       mean(gradient_segment, na.rm = TRUE)
   }

--- a/man/journey.Rd
+++ b/man/journey.Rd
@@ -15,14 +15,15 @@ journey(
   save_raw = "FALSE",
   cols = c("name", "distances", "time", "busynance", "elevations", "start_longitude",
     "start_latitude", "finish_longitude", "finish_latitude"),
-  cols_extra = c("crow_fly_distance", "event", "whence", "speed", "itinerary",
-    "clientRouteId", "plan", "note", "length", "quietness", "west", "south", "east",
-    "north", "leaving", "arriving", "grammesCO2saved", "calories", "edition",
-    "gradient_segment", "elevation_change", "provisionName"),
+  cols_extra = c("crow_fly_distance", "event", "whence", "speed", "itinerary", "plan",
+    "note", "length", "quietness", "west", "south", "east", "north", "leaving",
+    "arriving", "grammesCO2saved", "calories", "edition", "gradient_segment",
+    "elevation_change", "provisionName"),
   smooth_gradient = TRUE,
   distance_cutoff = 50,
   gradient_cutoff = 0.1,
-  n = 3
+  n = 3,
+  warnNA = TRUE
 )
 }
 \arguments{
@@ -55,7 +56,9 @@ https://github.com/Robinlovelace/cyclestreets/issues/14}
 
 \item{gradient_cutoff}{Gradient (\%, e.g. 0.1 being 10\%) used to identify anomalous gradients}
 
-\item{n}{The number of segments to use to smooth anomalous gradents.
+\item{n}{The number of segments to use to smooth anomalous gradents.}
+
+\item{warnNA}{Logical should NA warning be given?
 The default is 3, meaning segments directly before, after and including the offending segment.}
 }
 \description{
@@ -89,7 +92,7 @@ A full list of variables (\code{cols}) available is represented by:
 "name", "walk", "elevations", "distances", "start", "finish",
 "startSpeed", "start_longitude", "start_latitude", "finish_longitude",
 "finish_latitude", "crow_fly_distance", "event", "whence", "speed",
-"itinerary", "clientRouteId", "plan", "note", "length", "quietness",
+"itinerary", "plan", "note", "length", "quietness",
 "west", "south", "east", "north", "leaving", "arriving", "grammesCO2saved",
 "calories", "edition", "geometry")
 }\if{html}{\out{</div>}}

--- a/man/json2sf_cs.Rd
+++ b/man/json2sf_cs.Rd
@@ -12,7 +12,8 @@ json2sf_cs(
   smooth_gradient = FALSE,
   distance_cutoff = 50,
   gradient_cutoff = 0.1,
-  n = 3
+  n = 3,
+  warnNA = TRUE
 )
 }
 \arguments{
@@ -29,7 +30,9 @@ https://github.com/Robinlovelace/cyclestreets/issues/14}
 
 \item{gradient_cutoff}{Gradient (\%, e.g. 0.1 being 10\%) used to identify anomalous gradients}
 
-\item{n}{The number of segments to use to smooth anomalous gradents.
+\item{n}{The number of segments to use to smooth anomalous gradents.}
+
+\item{warnNA}{Logical should NA warning be given?
 The default is 3, meaning segments directly before, after and including the offending segment.}
 }
 \description{

--- a/man/smooth_with_cutoffs.Rd
+++ b/man/smooth_with_cutoffs.Rd
@@ -10,7 +10,8 @@ smooth_with_cutoffs(
   distances,
   distance_cutoff = 50,
   gradient_cutoff = 0.1,
-  n = 3
+  n = 3,
+  warnNA = TRUE
 )
 }
 \arguments{
@@ -24,7 +25,9 @@ smooth_with_cutoffs(
 
 \item{gradient_cutoff}{Gradient (\%, e.g. 0.1 being 10\%) used to identify anomalous gradients}
 
-\item{n}{The number of segments to use to smooth anomalous gradents.
+\item{n}{The number of segments to use to smooth anomalous gradents.}
+
+\item{warnNA}{Logical should NA warning be given?
 The default is 3, meaning segments directly before, after and including the offending segment.}
 }
 \description{

--- a/man/ways.Rd
+++ b/man/ways.Rd
@@ -10,8 +10,8 @@ ways(
   base_url = "https://api.cyclestreets.net/v2/mapdata?",
   limit = 400,
   types = "way",
- 
-    wayFields = "name,ridingSurface,id,cyclableText,quietness,speedMph,speedKmph,pause,color",
+  wayFields =
+    "name,ridingSurface,id,cyclableText,quietness,speedMph,speedKmph,pause,color",
   zoom = 16
 )
 }
@@ -30,12 +30,13 @@ See \href{https://www.cyclestreets.net/api/v2/}{API docs}.
 \examples{
 \dontrun{
 
-u = paste0("https://api.cyclestreets.net/v2/mapdata?key=c047ed46f7b50b18",
+u_test = paste0("https://api.cyclestreets.net/v2/mapdata?key=c047ed46f7b50b18",
   "&limit=400&types=way&wayFields=name,ridingSurface,id,cyclableText,",
   "quietness,speedMph,speedKmph,pause,color&zoom=16&",
   "bbox=-9.160863,38.754642,-9.150128,38.75764")
-ways_test = sf::read_sf(u)
+ways_test = sf::read_sf(u_test)
 bb <- "0.101131,52.195807,0.170288,52.209719"
+bb <- "-9.160863,38.754642,-9.150128,38.75764"
 way_data <- ways(bb)
 plot(way_data)
 bb <- stplanr::routes_fast_sf


### PR DESCRIPTION
I got this test failure

```
Duration: 30.2s

> checking Rd \usage sections ... WARNING
  Undocumented arguments in documentation object 'ways'
    'limit' 'types' 'wayFields' 'zoom'
  
  Functions with \usage entries need to have the appropriate \alias
  entries, and all their arguments documented.
  The \usage entries must correspond to syntactically valid R code.
  See chapter 'Writing R documentation files' in the 'Writing R
  Extensions' manual.

0 errors v | 1 warning x | 0 notes v
Error: R CMD check found WARNINGs
Execution halted

Exited with status 1.

```

But I don't think it is related to this PR